### PR TITLE
Escape the Query Paramater Questionmark

### DIFF
--- a/lua/weather.lua
+++ b/lua/weather.lua
@@ -55,7 +55,7 @@ function M.show_weather(city)
     city_param = ""
   end
 
-  local command = string.format("curl https://wttr.in/%s?0", city_param)
+  local command = string.format("curl https://wttr.in/%s'?'0", city_param)
   vim.api.nvim_call_function("termopen", {command})
 end
 


### PR DESCRIPTION
curl is failing when calling ```:Weather``` or even ```:Weather City``` as it is not able to escape the ```?``` properly and therefore returns an ```not found``` error. This change escapes the ```?``` and fixes this error.